### PR TITLE
⚡ Speed up test suite

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -53,6 +53,7 @@ def _run_tests(
     if extra_command:
         session.run(*extra_command, env=env)
     if "--cov" in session.posargs:
+        # Try to use the lighter-weight `sys.monitoring` coverage core available in Python 3.12+ to speed up coverage collection.
         env["COVERAGE_CORE"] = "sysmon"
     session.run(
         "uv",

--- a/noxfile.py
+++ b/noxfile.py
@@ -52,6 +52,8 @@ def _run_tests(
 
     if extra_command:
         session.run(*extra_command, env=env)
+    if "--cov" in session.posargs:
+        env["COVERAGE_CORE"] = "sysmon"
     session.run(
         "uv",
         "run",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,9 @@ report.exclude_also = [
     'raise AssertionError',
     'raise NotImplementedError',
 ]
+run.disable_warnings = [
+    "no-sysmon",
+]
 
 show_missing = true
 skip_empty = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,7 @@ addopts = [
     "--strict-markers",
     "--strict-config",
     "--showlocals",
-    "--numprocesses=auto",
+    "--numprocesses=auto",  # Automatically use all available CPU cores for parallel testing
 ]
 log_cli_level = "INFO"
 xfail_strict = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,8 @@ test = [
     "pytest>=8.3.5",
     "pytest-console-scripts>=1.4.1",
     "pytest-cov>=6.1.1",
+    "pytest-sugar>=1.0.0",
+    "pytest-xdist>=3.7.0",
 ]
 docs = [
     "furo>=2024.8.6",
@@ -97,8 +99,14 @@ version-file = "src/mqt/bench/_version.py"
 
 [tool.pytest.ini_options]
 minversion = "7.2"
-testpaths = ["tests"]
-addopts = ["-ra", "--strict-markers", "--strict-config", "--showlocals"]
+testpaths = ["tests/"]
+addopts = [
+    "-ra",
+    "--strict-markers",
+    "--strict-config",
+    "--showlocals",
+    "--numprocesses=auto",
+]
 log_cli_level = "INFO"
 xfail_strict = true
 filterwarnings = [

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -18,4 +18,6 @@ try:
 
     coverage.process_startup()
 except ImportError:
+    # The 'coverage' module is optional. If it is not installed, 
+    # we skip enabling multiprocess coverage collection.
     pass

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2023 - 2025 Chair for Design Automation, TUM
+# Copyright (c) 2025 Munich Quantum Software Company GmbH
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
+"""Site customization shim to enable multiprocess coverage collection in tests.
+
+See: https://coverage.readthedocs.io/en/latest/subprocess.html.
+"""
+
+from __future__ import annotations
+
+try:
+    import coverage
+
+    coverage.process_startup()
+except ImportError:
+    pass

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -18,6 +18,6 @@ try:
 
     coverage.process_startup()
 except ImportError:
-    # The 'coverage' module is optional. If it is not installed, 
+    # The 'coverage' module is optional. If it is not installed,
     # we skip enabling multiprocess coverage collection.
     pass

--- a/src/mqt/bench/targets/devices/ibm.py
+++ b/src/mqt/bench/targets/devices/ibm.py
@@ -86,7 +86,9 @@ def get_ibm_falcon_27() -> Target:
         [25, 26],
         [26, 25],
     ]
-    backend = GenericBackendV2(num_qubits=27, coupling_map=cmap, basis_gates=get_gateset("ibm_falcon"), noise_info=True)
+    backend = GenericBackendV2(
+        num_qubits=27, coupling_map=cmap, basis_gates=get_gateset("ibm_falcon"), noise_info=True, seed=42
+    )
     target = backend.target
     target.description = "ibm_falcon_27"
     return target
@@ -387,7 +389,7 @@ def get_ibm_falcon_127() -> Target:
     """Get the target for a 127-qubit IBM Falcon architecture."""
     cmap = _get_127_qubit_cmap()
     backend = GenericBackendV2(
-        num_qubits=127, coupling_map=cmap, basis_gates=get_gateset("ibm_falcon"), noise_info=True
+        num_qubits=127, coupling_map=cmap, basis_gates=get_gateset("ibm_falcon"), noise_info=True, seed=42
     )
     target = backend.target
     target.description = "ibm_falcon_127"
@@ -398,7 +400,9 @@ def get_ibm_falcon_127() -> Target:
 def get_ibm_eagle_127() -> Target:
     """Get the target for a 127-qubit IBM Eagle architecture."""
     cmap = _get_127_qubit_cmap()
-    backend = GenericBackendV2(num_qubits=127, coupling_map=cmap, basis_gates=get_gateset("ibm_eagle"), noise_info=True)
+    backend = GenericBackendV2(
+        num_qubits=127, coupling_map=cmap, basis_gates=get_gateset("ibm_eagle"), noise_info=True, seed=42
+    )
     target = backend.target
     target.description = "ibm_eagle_127"
     return target
@@ -709,7 +713,9 @@ def get_ibm_heron_133() -> Target:
         [131, 122],
         [132, 126],
     ]
-    backend = GenericBackendV2(num_qubits=133, coupling_map=cmap, basis_gates=get_gateset("ibm_heron"), noise_info=True)
+    backend = GenericBackendV2(
+        num_qubits=133, coupling_map=cmap, basis_gates=get_gateset("ibm_heron"), noise_info=True, seed=42
+    )
     target = backend.target
     target.description = "ibm_heron_133"
     return target
@@ -1072,7 +1078,9 @@ def get_ibm_heron_156() -> Target:
         [155, 139],
         [155, 154],
     ]
-    backend = GenericBackendV2(num_qubits=156, coupling_map=cmap, basis_gates=get_gateset("ibm_heron"), noise_info=True)
+    backend = GenericBackendV2(
+        num_qubits=156, coupling_map=cmap, basis_gates=get_gateset("ibm_heron"), noise_info=True, seed=42
+    )
     target = backend.target
     target.description = "ibm_heron_156"
     return target

--- a/src/mqt/bench/targets/devices/ibm.py
+++ b/src/mqt/bench/targets/devices/ibm.py
@@ -24,6 +24,8 @@ from ..gatesets import get_gateset
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_SEED = 42
+
 
 @register_device("ibm_falcon_27")
 def get_ibm_falcon_27() -> Target:
@@ -87,7 +89,7 @@ def get_ibm_falcon_27() -> Target:
         [26, 25],
     ]
     backend = GenericBackendV2(
-        num_qubits=27, coupling_map=cmap, basis_gates=get_gateset("ibm_falcon"), noise_info=True, seed=42
+        num_qubits=27, coupling_map=cmap, basis_gates=get_gateset("ibm_falcon"), noise_info=True, seed=DEFAULT_SEED
     )
     target = backend.target
     target.description = "ibm_falcon_27"
@@ -389,7 +391,7 @@ def get_ibm_falcon_127() -> Target:
     """Get the target for a 127-qubit IBM Falcon architecture."""
     cmap = _get_127_qubit_cmap()
     backend = GenericBackendV2(
-        num_qubits=127, coupling_map=cmap, basis_gates=get_gateset("ibm_falcon"), noise_info=True, seed=42
+        num_qubits=127, coupling_map=cmap, basis_gates=get_gateset("ibm_falcon"), noise_info=True, seed=DEFAULT_SEED
     )
     target = backend.target
     target.description = "ibm_falcon_127"
@@ -401,7 +403,7 @@ def get_ibm_eagle_127() -> Target:
     """Get the target for a 127-qubit IBM Eagle architecture."""
     cmap = _get_127_qubit_cmap()
     backend = GenericBackendV2(
-        num_qubits=127, coupling_map=cmap, basis_gates=get_gateset("ibm_eagle"), noise_info=True, seed=42
+        num_qubits=127, coupling_map=cmap, basis_gates=get_gateset("ibm_eagle"), noise_info=True, seed=DEFAULT_SEED
     )
     target = backend.target
     target.description = "ibm_eagle_127"
@@ -714,7 +716,7 @@ def get_ibm_heron_133() -> Target:
         [132, 126],
     ]
     backend = GenericBackendV2(
-        num_qubits=133, coupling_map=cmap, basis_gates=get_gateset("ibm_heron"), noise_info=True, seed=42
+        num_qubits=133, coupling_map=cmap, basis_gates=get_gateset("ibm_heron"), noise_info=True, seed=DEFAULT_SEED
     )
     target = backend.target
     target.description = "ibm_heron_133"
@@ -1079,7 +1081,7 @@ def get_ibm_heron_156() -> Target:
         [155, 154],
     ]
     backend = GenericBackendV2(
-        num_qubits=156, coupling_map=cmap, basis_gates=get_gateset("ibm_heron"), noise_info=True, seed=42
+        num_qubits=156, coupling_map=cmap, basis_gates=get_gateset("ibm_heron"), noise_info=True, seed=DEFAULT_SEED
     )
     target = backend.target
     target.description = "ibm_heron_156"

--- a/uv.lock
+++ b/uv.lock
@@ -621,6 +621,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/ff/b4c0dc78fbe20c3e59c0c7334de0c27eb4001a2b2017999af398bf730817/execnet-2.1.1.tar.gz", hash = "sha256:5189b52c6121c24feae288166ab41b32549c7e2348652736540b9e6e7d4e72e3", size = 166524, upload-time = "2024-04-08T09:04:19.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/09/2aea36ff60d16dd8879bdb2f5b3ee0ba8d08cbbdcdfe870e695ce3784385/execnet-2.1.1-py3-none-any.whl", hash = "sha256:26dee51f1b80cebd6d0ca8e74dd8745419761d3bef34163928cbebbdc4749fdc", size = 40612, upload-time = "2024-04-08T09:04:17.414Z" },
+]
+
+[[package]]
 name = "executing"
 version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1513,6 +1522,8 @@ dev = [
     { name = "pytest" },
     { name = "pytest-console-scripts" },
     { name = "pytest-cov" },
+    { name = "pytest-sugar" },
+    { name = "pytest-xdist" },
     { name = "qiskit", extra = ["visualization"] },
     { name = "setuptools-scm" },
     { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
@@ -1544,6 +1555,8 @@ test = [
     { name = "pytest" },
     { name = "pytest-console-scripts" },
     { name = "pytest-cov" },
+    { name = "pytest-sugar" },
+    { name = "pytest-xdist" },
 ]
 
 [package.metadata]
@@ -1564,6 +1577,8 @@ dev = [
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-console-scripts", specifier = ">=1.4.1" },
     { name = "pytest-cov", specifier = ">=6.1.1" },
+    { name = "pytest-sugar", specifier = ">=1.0.0" },
+    { name = "pytest-xdist", specifier = ">=3.7.0" },
     { name = "qiskit", extras = ["visualization"], specifier = ">=1.2.1" },
     { name = "setuptools-scm", specifier = ">=8.2" },
     { name = "sphinx", specifier = ">=7.4.7" },
@@ -1595,6 +1610,8 @@ test = [
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-console-scripts", specifier = ">=1.4.1" },
     { name = "pytest-cov", specifier = ">=6.1.1" },
+    { name = "pytest-sugar", specifier = ">=1.0.0" },
+    { name = "pytest-xdist", specifier = ">=3.7.0" },
 ]
 
 [[package]]
@@ -2307,6 +2324,33 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/18/99/668cade231f434aaa59bbfbf49469068d2ddd945000621d3d165d2e7dd7b/pytest_cov-6.2.1.tar.gz", hash = "sha256:25cc6cc0a5358204b8108ecedc51a9b57b34cc6b8c967cc2c01a4e00d8a67da2", size = 69432, upload-time = "2025-06-12T10:47:47.684Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bc/16/4ea354101abb1287856baa4af2732be351c7bee728065aed451b678153fd/pytest_cov-6.2.1-py3-none-any.whl", hash = "sha256:f5bc4c23f42f1cdd23c70b1dab1bbaef4fc505ba950d53e0081d0730dd7e86d5", size = 24644, upload-time = "2025-06-12T10:47:45.932Z" },
+]
+
+[[package]]
+name = "pytest-sugar"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pytest" },
+    { name = "termcolor" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/ac/5754f5edd6d508bc6493bc37d74b928f102a5fff82d9a80347e180998f08/pytest-sugar-1.0.0.tar.gz", hash = "sha256:6422e83258f5b0c04ce7c632176c7732cab5fdb909cb39cca5c9139f81276c0a", size = 14992, upload-time = "2024-02-01T18:30:36.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/fb/889f1b69da2f13691de09a111c16c4766a433382d44aa0ecf221deded44a/pytest_sugar-1.0.0-py3-none-any.whl", hash = "sha256:70ebcd8fc5795dc457ff8b69d266a4e2e8a74ae0c3edc749381c64b5246c8dfd", size = 10171, upload-time = "2024-02-01T18:30:29.395Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/dc/865845cfe987b21658e871d16e0a24e871e00884c545f246dd8f6f69edda/pytest_xdist-3.7.0.tar.gz", hash = "sha256:f9248c99a7c15b7d2f90715df93610353a485827bc06eefb6566d23f6400f126", size = 87550, upload-time = "2025-05-26T21:18:20.251Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/b2/0e802fde6f1c5b2f7ae7e9ad42b83fd4ecebac18a8a8c2f2f14e39dce6e1/pytest_xdist-3.7.0-py3-none-any.whl", hash = "sha256:7d3fbd255998265052435eb9daa4e99b62e6fb9cfb6efd1f858d4d8c0c7f0ca0", size = 46142, upload-time = "2025-05-26T21:18:18.759Z" },
 ]
 
 [[package]]
@@ -3342,6 +3386,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ec/fe/802052aecb21e3797b8f7902564ab6ea0d60ff8ca23952079064155d1ae1/tabulate-0.9.0.tar.gz", hash = "sha256:0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c", size = 81090, upload-time = "2022-10-06T17:21:48.54Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/40/44/4a5f08c96eb108af5cb50b41f76142f0afa346dfa99d5296fe7202a11854/tabulate-0.9.0-py3-none-any.whl", hash = "sha256:024ca478df22e9340661486f85298cff5f6dcdba14f3813e8830015b9ed1948f", size = 35252, upload-time = "2022-10-06T17:21:44.262Z" },
+]
+
+[[package]]
+name = "termcolor"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/6c/3d75c196ac07ac8749600b60b03f4f6094d54e132c4d94ebac6ee0e0add0/termcolor-3.1.0.tar.gz", hash = "sha256:6a6dd7fbee581909eeec6a756cff1d7f7c376063b14e4a298dc4980309e55970", size = 14324, upload-time = "2025-04-30T11:37:53.791Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/bd/de8d508070629b6d84a30d01d57e4a65c69aa7f5abe7560b8fad3b50ea59/termcolor-3.1.0-py3-none-any.whl", hash = "sha256:591dd26b5c2ce03b9e43f391264626557873ce1d379019786f99b0c2bee140aa", size = 7684, upload-time = "2025-04-30T11:37:52.382Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR speeds up the test suite by parallelizing test execution and using a lighter-weight monitor for coverage collection on Python 3.12+.
This is based on the blog post: https://blog.trailofbits.com/2025/05/01/making-pypis-test-suite-81-faster/ which is definitely worth a read.

Working that out even made me discover a small bug in our target generation logic, where the generation of the IBM device targets would not be entirely deterministic, and, hence, neither were the mapped level benchmarks mapped to IBM devices. See https://github.com/munich-quantum-toolkit/bench/pull/602/commits/4ed07f3fce0ab3f3e89b2623192fb9a79af76633.

This is a pretty easy win in terms of testing speed. On my desktop with 32-cores this reduced the test time from 32s to 9s.